### PR TITLE
Added ViewInterface::get() & ViewInterface::set()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "A view library.",
     "require": {
         "php": ">=5.5.0",
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~4.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/View.php
+++ b/src/View.php
@@ -43,7 +43,7 @@ class View implements ViewInterface
      */
     public function __set($key, $value)
     {
-        $this->data[$key] = $value;
+        $this->set($key, $value);
     }
 
 
@@ -51,12 +51,37 @@ class View implements ViewInterface
      * Gets the view data
      *
      * @param string $key The key.
+	 * @return mixed the view data.
      */
     public function __get($key)
     {
-        return $this->data[$key];
+        return $this->get($key);
     }
 
+	
+	/**
+     * Binds data to the view.
+     *
+     * @param string $key The key.
+     * @param mixed $value The value.
+     */
+    public function set($key, $value)
+	{
+		$this->data[$key] = $value;
+	}
+	
+	
+	/**
+     * Gets the view data.
+     *
+     * @param string $key The key.
+	 * @return mixed the view data.
+     */
+    public function get($key)
+	{
+		return $this->data[$key];
+	}
+	
 
     /**
      * Renders the view as a string.

--- a/src/View.php
+++ b/src/View.php
@@ -51,37 +51,37 @@ class View implements ViewInterface
      * Gets the view data
      *
      * @param string $key The key.
-	 * @return mixed the view data.
+     * @return mixed the view data.
      */
     public function __get($key)
     {
         return $this->get($key);
     }
 
-	
-	/**
+
+    /**
      * Binds data to the view.
      *
      * @param string $key The key.
      * @param mixed $value The value.
      */
     public function set($key, $value)
-	{
-		$this->data[$key] = $value;
-	}
-	
-	
-	/**
+    {
+        $this->data[$key] = $value;
+    }
+
+
+    /**
      * Gets the view data.
      *
      * @param string $key The key.
-	 * @return mixed the view data.
+     * @return mixed the view data.
      */
     public function get($key)
-	{
-		return $this->data[$key];
-	}
-	
+    {
+        return $this->data[$key];
+    }
+
 
     /**
      * Renders the view as a string.

--- a/src/ViewInterface.php
+++ b/src/ViewInterface.php
@@ -13,22 +13,41 @@ interface ViewInterface
 
 
     /**
-     * Binds data to the view.
+     * Binds data to the view using property access.
      *
      * @param string $key The key.
-     * @param string $value The value.
+     * @param mixed $value The value.
      */
     public function __set($key, $value);
 
-
+	
     /**
-     * Gets the view data
+     * Gets the view data using property access.
      *
      * @param string $key The key.
+	 * @return mixed the view data.
      */
     public function __get($key);
 
-
+	
+    /**
+     * Binds data to the view.
+     *
+     * @param string $key The key.
+     * @param mixed $value The value.
+     */
+    public function set($key, $value);
+	
+	
+	/**
+     * Gets the view data.
+     *
+     * @param string $key The key.
+	 * @return mixed the view data.
+     */
+    public function get($key);
+	
+	
     /**
      * Renders the view as a string.
      *

--- a/src/ViewInterface.php
+++ b/src/ViewInterface.php
@@ -39,15 +39,15 @@ interface ViewInterface
     public function set($key, $value);
 	
 	
-	/**
+    /**
      * Gets the view data.
      *
      * @param string $key The key.
-	 * @return mixed the view data.
+     * @return mixed the view data.
      */
     public function get($key);
-	
-	
+ 
+
     /**
      * Renders the view as a string.
      *

--- a/src/ViewInterface.php
+++ b/src/ViewInterface.php
@@ -25,7 +25,7 @@ interface ViewInterface
      * Gets the view data using property access.
      *
      * @param string $key The key.
-	 * @return mixed the view data.
+     * @return mixed the view data.
      */
     public function __get($key);
 


### PR DESCRIPTION
Adding an explicit ViewInterface::get() & ViewInterface::set() will allow objects to be truely polymorphic instead of relying on the magic __set() & __get() which is used as property assignment on the implementing side. Also downgraded phpunit version as 5.5+ is for php 5.6 not php 5.5!
